### PR TITLE
out proper json

### DIFF
--- a/malwarebazaar/commands/query.py
+++ b/malwarebazaar/commands/query.py
@@ -1,4 +1,5 @@
 import click
+from json import dumps
 from rich.status import Status
 
 from malwarebazaar.api import Bazaar
@@ -54,7 +55,7 @@ def query(limit, json, csv, query_type, query):
         exit(-1)
 
     if json:
-        c.print(res["data"])
+        c.print(dumps(res["data"], indent=2))
     elif csv:
         samples = [Sample(**sample) for sample in res["data"]]
         c.print("md5,sha1,sha256,imphash,signature")


### PR DESCRIPTION
Currently the -j/-json option in query command does not output valid json as it simply prints the dict. This fixes the issue.