### PR TITLE
Fix typing with mypy, add marker file

### DIFF
--- a/malwarebazaar/api.py
+++ b/malwarebazaar/api.py
@@ -78,11 +78,11 @@ class Bazaar:
                 print(
                     f"As Bazaar only supports grabbing the last 100 samples, we're going to use 100 instead of {selector}."
                 )
-            selector = {"selector": 100}
+            query_selector = {"selector": "100"}
         else:
-            selector = {"selector": "time"}
+            query_selector = {"selector": "time"}
         return self.session.post(
-            self.baseurl, data={"query": "get_recent", **selector}
+            self.baseurl, data={"query": "get_recent", **query_selector}
         ).json()
 
     def download_file(self, sha256_hash) -> bytes:

--- a/malwarebazaar/commands/download.py
+++ b/malwarebazaar/commands/download.py
@@ -1,5 +1,5 @@
 import io
-import pyzipper
+import pyzipper  # type: ignore
 import click
 from rich.status import Status
 

--- a/malwarebazaar/commands/version.py
+++ b/malwarebazaar/commands/version.py
@@ -7,7 +7,7 @@ from rich.console import Console
 from malwarebazaar import version as ver
 
 try:
-    from malwarebazaar import commit
+    from malwarebazaar import commit  # type: ignore
 
     IS_BINARY = True
 except ImportError:

--- a/malwarebazaar/output.py
+++ b/malwarebazaar/output.py
@@ -1,4 +1,4 @@
-from typing import Optional, List
+from typing import List
 
 from rich.console import Console
 
@@ -6,7 +6,7 @@ from malwarebazaar.config import Config
 from malwarebazaar.sample import Sample
 
 
-def single_sample(s: Sample, console: Optional[Console] = Console()):
+def single_sample(s: Sample, console: Console = Console()):
     console.print(f"Filename:\t{s.file_name}")
     console.print(f"MD5:\t\t{s.md5_hash}")
     console.print(f"SHA1:\t\t{s.sha1_hash}")
@@ -16,15 +16,15 @@ def single_sample(s: Sample, console: Optional[Console] = Console()):
     console.print(f"Tags:\t\t{', '.join(s.tags or [])}")
 
 
-def multiple_samples(samples: List[Sample], console: Optional[Console] = Console()):
+def multiple_samples(samples: List[Sample], console: Console = Console()):
     for sample in samples:
         single_sample(sample, console)
         console.print()
 
 
-def csv_output(samples: List[Sample], console: Optional[Console] = Console()):
+def csv_output(samples: List[Sample], console: Console = Console()):
     columns = Config.get_instance()["csv_columns"]
-    console.print("\"",end="")
+    console.print("\"", end="")
     console.print("\",\"".join(columns.keys()), end="")
     console.print("\"")
     for idx, sample in enumerate(samples):

--- a/malwarebazaar/platform.py
+++ b/malwarebazaar/platform.py
@@ -23,9 +23,13 @@ def get_config_dir(ec: Console = Console(stderr=True, style="bold red")) -> str:
     if u_env:
         return u_env
     if is_linux() or is_darwin():
-        u_path = os.path.abspath(os.path.join(os.getenv("HOME"), ".config", "bazaar"))
+        if not os.getenv("HOME"):
+            raise Exception('Unable to get environment variable "HOME"')
+        u_path = os.path.abspath(os.path.join(os.environ["HOME"], ".config", "bazaar"))
     elif is_win():
-        u_path = os.path.abspath(os.path.join(os.getenv("APPDATA"), "bazaar"))
+        if not os.getenv("APPDATA"):
+            raise Exception('Unable to get environment variable "APPDATA"')
+        u_path = os.path.abspath(os.path.join(os.environ["APPDATA"], "bazaar"))
     else:
         ec.print(f"Unknown platform: {platform}.")
         exit(-1)

--- a/poetry.lock
+++ b/poetry.lock
@@ -105,6 +105,23 @@ python-versions = "*"
 altgraph = ">=0.15"
 
 [[package]]
+name = "mypy"
+version = "0.931"
+description = "Optional static typing for Python"
+category = "dev"
+optional = false
+python-versions = ">=3.6"
+
+[package.dependencies]
+mypy-extensions = ">=0.4.3"
+tomli = ">=1.1.0"
+typing-extensions = ">=3.10"
+
+[package.extras]
+dmypy = ["psutil (>=4.0)"]
+python2 = ["typed-ast (>=1.4.0,<2)"]
+
+[[package]]
 name = "mypy-extensions"
 version = "0.4.3"
 description = "Experimental type system extensions for programs checked with the mypy typechecker."
@@ -256,6 +273,33 @@ optional = false
 python-versions = ">=3.7"
 
 [[package]]
+name = "types-pyyaml"
+version = "6.0.4"
+description = "Typing stubs for PyYAML"
+category = "dev"
+optional = false
+python-versions = "*"
+
+[[package]]
+name = "types-requests"
+version = "2.27.10"
+description = "Typing stubs for requests"
+category = "dev"
+optional = false
+python-versions = "*"
+
+[package.dependencies]
+types-urllib3 = "<1.27"
+
+[[package]]
+name = "types-urllib3"
+version = "1.26.9"
+description = "Typing stubs for urllib3"
+category = "dev"
+optional = false
+python-versions = "*"
+
+[[package]]
 name = "typing-extensions"
 version = "4.1.1"
 description = "Backported and Experimental Type Hints for Python 3.6+"
@@ -279,7 +323,7 @@ socks = ["PySocks (>=1.5.6,!=1.5.7,<2.0)"]
 [metadata]
 lock-version = "1.1"
 python-versions = "^3.8,<3.11"
-content-hash = "1907aa19237447be71d53be18f1d490620aa95e9e09a7cd491e69624d22fe676"
+content-hash = "f0cf727865f494946b75fcc9d1a5ed2ecdfd934863c00bb58954bdc659b9bbfc"
 
 [metadata.files]
 altgraph = [
@@ -340,6 +384,28 @@ idna = [
 macholib = [
     {file = "macholib-1.15.2-py2.py3-none-any.whl", hash = "sha256:885613dd02d3e26dbd2b541eb4cc4ce611b841f827c0958ab98656e478b9e6f6"},
     {file = "macholib-1.15.2.tar.gz", hash = "sha256:1542c41da3600509f91c165cb897e7e54c0e74008bd8da5da7ebbee519d593d2"},
+]
+mypy = [
+    {file = "mypy-0.931-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:3c5b42d0815e15518b1f0990cff7a705805961613e701db60387e6fb663fe78a"},
+    {file = "mypy-0.931-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:c89702cac5b302f0c5d33b172d2b55b5df2bede3344a2fbed99ff96bddb2cf00"},
+    {file = "mypy-0.931-cp310-cp310-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:300717a07ad09525401a508ef5d105e6b56646f7942eb92715a1c8d610149714"},
+    {file = "mypy-0.931-cp310-cp310-win_amd64.whl", hash = "sha256:7b3f6f557ba4afc7f2ce6d3215d5db279bcf120b3cfd0add20a5d4f4abdae5bc"},
+    {file = "mypy-0.931-cp36-cp36m-macosx_10_9_x86_64.whl", hash = "sha256:1bf752559797c897cdd2c65f7b60c2b6969ffe458417b8d947b8340cc9cec08d"},
+    {file = "mypy-0.931-cp36-cp36m-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:4365c60266b95a3f216a3047f1d8e3f895da6c7402e9e1ddfab96393122cc58d"},
+    {file = "mypy-0.931-cp36-cp36m-win_amd64.whl", hash = "sha256:1b65714dc296a7991000b6ee59a35b3f550e0073411ac9d3202f6516621ba66c"},
+    {file = "mypy-0.931-cp37-cp37m-macosx_10_9_x86_64.whl", hash = "sha256:e839191b8da5b4e5d805f940537efcaa13ea5dd98418f06dc585d2891d228cf0"},
+    {file = "mypy-0.931-cp37-cp37m-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:50c7346a46dc76a4ed88f3277d4959de8a2bd0a0fa47fa87a4cde36fe247ac05"},
+    {file = "mypy-0.931-cp37-cp37m-win_amd64.whl", hash = "sha256:d8f1ff62f7a879c9fe5917b3f9eb93a79b78aad47b533911b853a757223f72e7"},
+    {file = "mypy-0.931-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:f9fe20d0872b26c4bba1c1be02c5340de1019530302cf2dcc85c7f9fc3252ae0"},
+    {file = "mypy-0.931-cp38-cp38-macosx_11_0_arm64.whl", hash = "sha256:1b06268df7eb53a8feea99cbfff77a6e2b205e70bf31743e786678ef87ee8069"},
+    {file = "mypy-0.931-cp38-cp38-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:8c11003aaeaf7cc2d0f1bc101c1cc9454ec4cc9cb825aef3cafff8a5fdf4c799"},
+    {file = "mypy-0.931-cp38-cp38-win_amd64.whl", hash = "sha256:d9d2b84b2007cea426e327d2483238f040c49405a6bf4074f605f0156c91a47a"},
+    {file = "mypy-0.931-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:ff3bf387c14c805ab1388185dd22d6b210824e164d4bb324b195ff34e322d166"},
+    {file = "mypy-0.931-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:5b56154f8c09427bae082b32275a21f500b24d93c88d69a5e82f3978018a0266"},
+    {file = "mypy-0.931-cp39-cp39-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:8ca7f8c4b1584d63c9a0f827c37ba7a47226c19a23a753d52e5b5eddb201afcd"},
+    {file = "mypy-0.931-cp39-cp39-win_amd64.whl", hash = "sha256:74f7eccbfd436abe9c352ad9fb65872cc0f1f0a868e9d9c44db0893440f0c697"},
+    {file = "mypy-0.931-py3-none-any.whl", hash = "sha256:1171f2e0859cfff2d366da2c7092b06130f232c636a3f7301e3feb8b41f6377d"},
+    {file = "mypy-0.931.tar.gz", hash = "sha256:0038b21890867793581e4cb0d810829f5fd4441aa75796b53033af3aa30430ce"},
 ]
 mypy-extensions = [
     {file = "mypy_extensions-0.4.3-py2.py3-none-any.whl", hash = "sha256:090fedd75945a69ae91ce1303b5824f428daf5a028d2f6ab8a299250a846f15d"},
@@ -460,6 +526,18 @@ rich = [
 tomli = [
     {file = "tomli-2.0.1-py3-none-any.whl", hash = "sha256:939de3e7a6161af0c887ef91b7d41a53e7c5a1ca976325f429cb46ea9bc30ecc"},
     {file = "tomli-2.0.1.tar.gz", hash = "sha256:de526c12914f0c550d15924c62d72abc48d6fe7364aa87328337a31007fe8a4f"},
+]
+types-pyyaml = [
+    {file = "types-PyYAML-6.0.4.tar.gz", hash = "sha256:6252f62d785e730e454dfa0c9f0fb99d8dae254c5c3c686903cf878ea27c04b7"},
+    {file = "types_PyYAML-6.0.4-py3-none-any.whl", hash = "sha256:693b01c713464a6851f36ff41077f8adbc6e355eda929addfb4a97208aea9b4b"},
+]
+types-requests = [
+    {file = "types-requests-2.27.10.tar.gz", hash = "sha256:5dcb088fcaa778efeee6b7fc46967037e983fbfb9fec02594578bd33fd75e555"},
+    {file = "types_requests-2.27.10-py3-none-any.whl", hash = "sha256:6cb4fb0bbcbc585c57eeee6ffe5a47638dc89706b8d290ec89a77213fc5bad1a"},
+]
+types-urllib3 = [
+    {file = "types-urllib3-1.26.9.tar.gz", hash = "sha256:abd2d4857837482b1834b4817f0587678dcc531dbc9abe4cde4da28cef3f522c"},
+    {file = "types_urllib3-1.26.9-py3-none-any.whl", hash = "sha256:4a54f6274ab1c80968115634a55fb9341a699492b95e32104a7c513db9fe02e9"},
 ]
 typing-extensions = [
     {file = "typing_extensions-4.1.1-py3-none-any.whl", hash = "sha256:21c85e0fe4b9a155d0799430b0ad741cdce7e359660ccbd8b530613e8df88ce2"},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,6 +26,9 @@ pyzipper = "^0.3.5"
 [tool.poetry.dev-dependencies]
 pyinstaller = "^4.9"
 black = "^22.1.0"
+mypy = "^0.931"
+types-PyYAML = "^6.0.4"
+types-requests = "^2.27.10"
 
 [build-system]
 requires = ["poetry-core>=1.0.0"]


### PR DESCRIPTION
Just a few changes to make mypy happy and allow the code using this module to use on the typing ([py.typed](https://www.python.org/dev/peps/pep-0561/#packaging-type-information)).

A few notes: 
* `query_recent` ignores the actual value of `selector` and always passes either `100` or `time`. I made 100 a string because the `data` parameter in `post` seems to expect `Dict[str, str]`, I didn't investigate further, but passing an `int` shouldn't be an issue and I'm unsure why mypy complained.
* Not sure what `from malwarebazaar import commit` is in `malwarebazaar/commands/version.py`? 
* os.path.join with a potential `None` part would cause an exception anyway, so I just raise one.