### PR TITLE
chg: Remove dependency on setuptools

### DIFF
--- a/malwarebazaar/__init__.py
+++ b/malwarebazaar/__init__.py
@@ -1,4 +1,4 @@
-from malwarebazaar.api import Bazaar, Yaraify
-import pkg_resources
+from importlib.metadata import version
+from malwarebazaar.api import Bazaar, Yaraify  # noqa
 
-version = "v" + pkg_resources.get_distribution('malwarebazaar').version
+version = f"v{version('malwarebazaar')}"


### PR DESCRIPTION
If `setuptools` is not installed (which seem to be the case now a days), malwarebazaar fails to load because `pkg_resources` is missing. The new way to do the same is to use `importlib.metadata.version` now, which comes with python directly.

The alternative to that is to add `setuptools` in the dependencies.