### PR TITLE
chg: remove python 3.8 (EOL), add python 3.13

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,7 +16,7 @@ homepage = "https://github.com/3c7/bazaar"
 repository = "https://github.com/3c7/bazaar"
 
 [tool.poetry.dependencies]
-python = "^3.8,<3.13"
+python = "^3.9,<3.14"
 requests = "^2.31.0"
 PyYAML = "^6.0.1"
 pyzipper = "^0.3.6"


### PR DESCRIPTION
Nothing crazy, just allowing to install the package on python 3.13 (and remove python 3.8, as it is EOL).