### PR TITLE
fix: Header to pass the key changed name

### DIFF
--- a/malwarebazaar/api/bazaar.py
+++ b/malwarebazaar/api/bazaar.py
@@ -1,4 +1,4 @@
-from typing import Optional, Dict, Union, Text
+from typing import Optional, Dict
 
 from requests import Session
 
@@ -6,7 +6,7 @@ from requests import Session
 class Bazaar:
     def __init__(self, api_key: str):
         self.session = Session()
-        self.session.headers.update({"API-KEY": api_key})
+        self.session.headers.update({"Auth-Key": api_key})
         self.baseurl = "https://mb-api.abuse.ch/api/v1/"
 
     def query_hash(self, hash: str) -> Dict:


### PR DESCRIPTION
The headers name changed and it fails with API-KEY.